### PR TITLE
Removed DoNotMap flag from the high-tier laser pistols

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Battery/battery_pistols.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Battery/battery_pistols.yml
@@ -28,7 +28,6 @@
     autoRecharge: false
 
 - type: entity
-  categories: [ DoNotMap ]
   id: NFWeaponEnergyPistolLaserAntique
   parent: [ NFBaseWeaponEnergyPistolFireModes, NFBaseWeaponFrameEnergyPistolNanotrasen ]
   name: antique laser pistol
@@ -57,7 +56,6 @@
       - state: inhand-right
 
 - type: entity
-  categories: [ DoNotMap ]
   id: NFWeaponEnergyPistolLaserX01Multiphase
   parent: [ BaseC2ContrabandUnredeemable, NFWeaponEnergyPistolLaserAntique ]
   name: X-01 multiphase energy gun


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Very basic commit to allow high-tier laser pistols to be mappable.

## Why / Balance
Stinkus' most recent mapping changes threw and error and it was only disabled because of Frontier balancing that doesnt apply to us

## Technical details
yaml

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: antique laser pistol and multiphase energy gun are now allowed in mapping
