### PR TITLE
Expedition and FTL Changes

### DIFF
--- a/Content.Client/Shuttles/UI/MapScreen.xaml.cs
+++ b/Content.Client/Shuttles/UI/MapScreen.xaml.cs
@@ -569,8 +569,8 @@ public sealed partial class MapScreen : BoxContainer
         if (_entManager.TryGetComponent(_shuttleEntity, out TransformComponent? shuttleXform))
         {
             SetMap(shuttleXform.MapID, _maps.GetGridPosition((_shuttleEntity.Value, null, shuttleXform)));
-            RebuildMapObjects();
-            BumpMapDequeue();
+            RebuildMapObjects(); // Scav
+            BumpMapDequeue(); // Scav
         }
     }
 }

--- a/Content.Client/Shuttles/UI/MapScreen.xaml.cs
+++ b/Content.Client/Shuttles/UI/MapScreen.xaml.cs
@@ -116,16 +116,6 @@ public sealed partial class MapScreen : BoxContainer
         MapRadar.InFtl = true;
         MapFTLState.Text = Loc.GetString($"shuttle-console-ftl-state-{_state.ToString()}");
 
-        /*//frontier - we only allow pre-approved vessels to FTL
-        if (!_entManager.HasComponent<ShuttleFTLComponent>(_shuttleEntity))
-        {
-            MapFTLButton.Visible = false;
-        }
-        else
-        {
-            MapFTLButton.Visible = true;
-        }*/
-
         switch (_state)
         {
             case FTLState.Available:

--- a/Content.Client/Shuttles/UI/MapScreen.xaml.cs
+++ b/Content.Client/Shuttles/UI/MapScreen.xaml.cs
@@ -579,6 +579,8 @@ public sealed partial class MapScreen : BoxContainer
         if (_entManager.TryGetComponent(_shuttleEntity, out TransformComponent? shuttleXform))
         {
             SetMap(shuttleXform.MapID, _maps.GetGridPosition((_shuttleEntity.Value, null, shuttleXform)));
+            RebuildMapObjects();
+            BumpMapDequeue();
         }
     }
 }

--- a/Content.Client/Shuttles/UI/MapScreen.xaml.cs
+++ b/Content.Client/Shuttles/UI/MapScreen.xaml.cs
@@ -116,7 +116,7 @@ public sealed partial class MapScreen : BoxContainer
         MapRadar.InFtl = true;
         MapFTLState.Text = Loc.GetString($"shuttle-console-ftl-state-{_state.ToString()}");
 
-        //frontier - we only allow pre-approved vessels to FTL
+        /*//frontier - we only allow pre-approved vessels to FTL
         if (!_entManager.HasComponent<ShuttleFTLComponent>(_shuttleEntity))
         {
             MapFTLButton.Visible = false;
@@ -124,7 +124,7 @@ public sealed partial class MapScreen : BoxContainer
         else
         {
             MapFTLButton.Visible = true;
-        }
+        }*/
 
         switch (_state)
         {

--- a/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
@@ -72,7 +72,7 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
     private readonly Dictionary<Color, List<(Vector2, string)>> _strings = new();
     private readonly List<ShuttleExclusionObject> _viewportExclusions = new();
 
-    public ShuttleMapControl() : base(256f, 512f, 512f)
+    public ShuttleMapControl() : base(256f, 1024f, 512f)
     {
         RobustXamlLoader.Load(this);
         _mapSystem = EntManager.System<SharedMapSystem>();

--- a/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
@@ -72,7 +72,7 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
     private readonly Dictionary<Color, List<(Vector2, string)>> _strings = new();
     private readonly List<ShuttleExclusionObject> _viewportExclusions = new();
 
-    public ShuttleMapControl() : base(256f, 1024f, 512f)
+    public ShuttleMapControl() : base(1024f, 16384f, 12288f)
     {
         RobustXamlLoader.Load(this);
         _mapSystem = EntManager.System<SharedMapSystem>();
@@ -88,7 +88,7 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
     public void SetMap(MapId mapId, Vector2 offset, bool recentering = false)
     {
         ViewingMap = mapId;
-        TargetOffset = offset;
+        TargetOffset = Vector2.Zero; // Scav: Force this to center and ignore input offset, we want to display the whole sector.
         Recentering = recentering;
     }
 
@@ -250,7 +250,7 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
             return;
         }
 
-        DrawParallax(handle);
+        DrawBacking(handle);
 
         var viewedMapUid = _mapSystem.GetMapOrInvalid(ViewingMap);
         var matty = Matrix3Helpers.CreateInverseTransform(Offset, Angle.Zero);
@@ -346,6 +346,13 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
             Entity<MapGridComponent> grid = (gridObj.Entity, mapGrid);
             IFFComponent? iffComp = null;
 
+            // Scav: hide items on different maps from the one we're viewing
+            if (_xformSystem.GetMapId(grid.Owner) != ViewingMap)
+            {
+                continue;
+            }
+            // End Scav
+
             // Rudimentary IFF for now, if IFF hiding on then we don't show on the map at all
             if (grid.Owner != _shuttleEntity &&
                 EntManager.TryGetComponent(grid, out iffComp) &&
@@ -367,8 +374,18 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
             gridRelativePos = gridRelativePos with { Y = -gridRelativePos.Y };
             var gridUiPos = ScalePosition(gridRelativePos);
 
-            var mapObject = GetMapObject(gridRelativePos, Angle.Zero, scalePosition: true);
-            AddMapObject(existingEdges, existingVerts, mapObject);
+            //Scav: new directional icon for shuttle
+            if (grid.Owner == _shuttleEntity)
+            {
+                var mapObject = GetMapObjectDirectional(gridRelativePos, -gridRot, scalePosition: true);
+                AddMapObject(existingEdges, existingVerts, mapObject);
+            }
+            else
+            {
+                var mapObject = GetMapObject(gridRelativePos, Angle.Zero, scalePosition: true);
+                AddMapObject(existingEdges, existingVerts, mapObject);
+            }
+            //End Scav
 
             // Text
             if (iffComp != null && (iffComp.Flags & IFFFlags.HideLabel) != 0x0)
@@ -457,7 +474,7 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
                     handle.DrawDottedLine(gridUiPos, mouseLocalPos, color, (float) realTime.TotalSeconds * 30f);
 
                     // Draw shuttle pre-vis
-                    var mouseVerts = GetMapObject(mouseLocalPos, _ftlAngle, scale: MinimapScale);
+                    var mouseVerts = GetMapObjectDirectional(mouseLocalPos, _ftlAngle, scale: MinimapScale);
 
                     handle.DrawPrimitives(DrawPrimitiveTopology.TriangleFan, mouseVerts.Span, color.WithAlpha(0.05f));
                     handle.DrawPrimitives(DrawPrimitiveTopology.LineLoop, mouseVerts.Span, color);
@@ -547,6 +564,30 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
             localPos + angle.RotateVec(new Vector2(diamondRadius, 0f)) * scale,
             localPos + angle.RotateVec(new Vector2(0f, 2f * diamondRadius)) * scale,
             localPos + angle.RotateVec(new Vector2(-diamondRadius, 0f)) * scale,
+        };
+
+        if (scalePosition)
+        {
+            for (var i = 0; i < mapObj.Count; i++)
+            {
+                mapObj[i] = ScalePosition(mapObj[i]);
+            }
+        }
+
+        return mapObj;
+    }
+
+    private ValueList<Vector2> GetMapObjectDirectional(Vector2 localPos, Angle angle, float scale = 1f, bool scalePosition = false)
+    {
+        // Constant size diamonds
+        var objectRadius = GetMapObjectRadius();
+
+        var mapObj = new ValueList<Vector2>(4)
+        {
+            localPos + angle.RotateVec(new Vector2(0f, 0.4f) * objectRadius) * scale,
+            localPos + angle.RotateVec(new Vector2(1f, 1f) * objectRadius) * scale,
+            localPos + angle.RotateVec(new Vector2(0f, -2f) * objectRadius) * scale,
+            localPos + angle.RotateVec(new Vector2(-1, 1f) * objectRadius) * scale,
         };
 
         if (scalePosition)

--- a/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
@@ -72,7 +72,7 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
     private readonly Dictionary<Color, List<(Vector2, string)>> _strings = new();
     private readonly List<ShuttleExclusionObject> _viewportExclusions = new();
 
-    public ShuttleMapControl() : base(1024f, 16384f, 12288f)
+    public ShuttleMapControl() : base(1024f, 16384f, 12288f) // Scav: (256f, 512f, 512f)<(1024f, 16384f, 12288f)
     {
         RobustXamlLoader.Load(this);
         _mapSystem = EntManager.System<SharedMapSystem>();
@@ -250,7 +250,7 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
             return;
         }
 
-        DrawBacking(handle);
+        DrawBacking(handle); // Scav: no longer drawing parallax, just blank background
 
         var viewedMapUid = _mapSystem.GetMapOrInvalid(ViewingMap);
         var matty = Matrix3Helpers.CreateInverseTransform(Offset, Angle.Zero);
@@ -474,7 +474,7 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
                     handle.DrawDottedLine(gridUiPos, mouseLocalPos, color, (float) realTime.TotalSeconds * 30f);
 
                     // Draw shuttle pre-vis
-                    var mouseVerts = GetMapObjectDirectional(mouseLocalPos, _ftlAngle, scale: MinimapScale);
+                    var mouseVerts = GetMapObjectDirectional(mouseLocalPos, _ftlAngle, scale: MinimapScale); //Scav: changed to Directional variant
 
                     handle.DrawPrimitives(DrawPrimitiveTopology.TriangleFan, mouseVerts.Span, color.WithAlpha(0.05f));
                     handle.DrawPrimitives(DrawPrimitiveTopology.LineLoop, mouseVerts.Span, color);
@@ -577,6 +577,7 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
         return mapObj;
     }
 
+    // Scav: New variant for arrow instead of diamond
     private ValueList<Vector2> GetMapObjectDirectional(Vector2 localPos, Angle angle, float scale = 1f, bool scalePosition = false)
     {
         // Constant size diamonds
@@ -600,6 +601,7 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
 
         return mapObj;
     }
+    // End Scav
 
     private bool TryGetBeacon(IEnumerable<IMapObject> mapObjects, Matrix3x2 mapTransform, Vector2 mousePos, UIBox2i area, out ShuttleBeaconObject foundBeacon, out Vector2 foundLocalPos)
     {

--- a/Content.Client/UserInterface/Controls/MapGridControl.xaml.cs
+++ b/Content.Client/UserInterface/Controls/MapGridControl.xaml.cs
@@ -20,7 +20,7 @@ public partial class MapGridControl : LayoutContainer
     [Dependency] protected readonly IEntityManager EntManager = default!;
     [Dependency] protected readonly IGameTiming Timing = default!;
 
-    protected static readonly Color BackingColor = new Color(0.08f, 0.08f, 0.08f);
+    protected static readonly Color BackingColor = new Color(0.05f, 0.05f, 0.05f); //Scav: Darker background
 
     private Font _largerFont;
 

--- a/Content.Server/Salvage/SalvageSystem.ExpeditionConsole.cs
+++ b/Content.Server/Salvage/SalvageSystem.ExpeditionConsole.cs
@@ -57,57 +57,8 @@ public sealed partial class SalvageSystem
         }
         // End Frontier
 
-        // var cdUid = Spawn(CoordinatesDisk, Transform(uid).Coordinates); // Frontier: no disk-based FTL
-        // SpawnMission(missionparams, station.Value, cdUid); // Frontier: no disk-based FTL
-
-        // Frontier: FTL travel is currently restricted to expeditions and such, and so we need to put this here
-        #region Frontier FTL changes
-        // until FTL changes for us in some way.
-
-        // Run a proximity check (unless using a debug console)
-        if (_salvage.ProximityCheck && !component.Debug)
-        {
-            if (!TryComp<StationDataComponent>(station, out var stationData)
-                || _station.GetLargestGrid(stationData) is not { Valid: true } ourGrid
-                || !TryComp<MapGridComponent>(ourGrid, out var gridComp))
-            {
-                PlayDenySound((uid, component));
-                _popupSystem.PopupEntity(Loc.GetString("shuttle-ftl-invalid"), uid, PopupType.MediumCaution);
-                UpdateConsoles((station.Value, data));
-                return;
-            }
-
-            if (HasComp<FTLComponent>(ourGrid))
-            {
-                PlayDenySound((uid, component));
-                _popupSystem.PopupEntity(Loc.GetString("shuttle-ftl-recharge"), uid, PopupType.MediumCaution);
-                UpdateConsoles((station.Value, data));
-                return;
-            }
-
-            var xform = Transform(ourGrid);
-            var bounds = _transform.GetWorldMatrix(ourGrid).TransformBox(gridComp.LocalAABB).Enlarged(ShuttleFTLRange);
-            var bodyQuery = GetEntityQuery<PhysicsComponent>();
-            var otherGrids = new List<Entity<MapGridComponent>>();
-            _mapManager.FindGridsIntersecting(xform.MapID, bounds, ref otherGrids);
-            foreach (var otherGrid in otherGrids)
-            {
-                if (ourGrid == otherGrid.Owner ||
-                    !bodyQuery.TryGetComponent(otherGrid.Owner, out var body) ||
-                    body.Mass < ShuttleFTLMassThreshold && body.BodyType == BodyType.Dynamic)
-                {
-                    continue;
-                }
-
-                PlayDenySound((uid, component));
-                _popupSystem.PopupEntity(Loc.GetString("shuttle-ftl-proximity"), uid, PopupType.MediumCaution);
-                UpdateConsoles((station.Value, data));
-                return;
-            }
-        }
-        SpawnMission(missionparams, station.Value, null);
-        #endregion Frontier FTL changes
-        // End Frontier
+        var cdUid = Spawn(CoordinatesDisk, Transform(uid).Coordinates);
+        SpawnMission(missionparams, station.Value, cdUid);
 
         data.ActiveMission = args.Index;
         var mission = GetMission(missionparams.MissionType, _prototypeManager.Index<SalvageDifficultyPrototype>(missionparams.Difficulty), missionparams.Seed); // Frontier: add MissionType
@@ -115,8 +66,8 @@ public sealed partial class SalvageSystem
         data.NextOffer = _timing.CurTime + mission.Duration + TimeSpan.FromSeconds(1);
         data.CooldownTime = mission.Duration + TimeSpan.FromSeconds(1); // Frontier
 
-        // _labelSystem.Label(cdUid, GetFTLName(_prototypeManager.Index(PlanetNames), missionparams.Seed)); // Frontier: no disc
-        // _audio.PlayPvs(component.PrintSound, uid); // Frontier: no disc
+        _labelSystem.Label(cdUid, GetFTLName(_prototypeManager.Index(PlanetNames), missionparams.Seed));
+        _audio.PlayPvs(component.PrintSound, uid);
 
         UpdateConsoles((station.Value, data));
     }

--- a/Content.Server/Salvage/SalvageSystem.cs
+++ b/Content.Server/Salvage/SalvageSystem.cs
@@ -33,6 +33,7 @@ namespace Content.Server.Salvage
         [Dependency] private readonly BiomeSystem _biome = default!;
         [Dependency] private readonly DungeonSystem _dungeon = default!;
         [Dependency] private readonly GravitySystem _gravity = default!;
+        [Dependency] private readonly LabelSystem _labelSystem = default!;
         [Dependency] private readonly MapLoaderSystem _loader = default!;
         [Dependency] private readonly MetaDataSystem _metaData = default!;
         [Dependency] private readonly RadioSystem _radioSystem = default!;

--- a/Content.Server/Salvage/SpawnSalvageMissionJob.cs
+++ b/Content.Server/Salvage/SpawnSalvageMissionJob.cs
@@ -388,14 +388,6 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
             }
         }
 
-        // Frontier: delay ship FTL
-        if (shuttleUid is { Valid: true })
-        {
-            var shuttle = _entManager.GetComponent<ShuttleComponent>(shuttleUid.Value);
-            _shuttle.FTLToCoordinates(shuttleUid.Value, shuttle, new EntityCoordinates(mapUid, coords), 0f, 5.5f, _salvage.TravelTime);
-        }
-        // End Frontier
-
         return true;
     }
 

--- a/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
+++ b/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
@@ -23,7 +23,7 @@ public abstract partial class SharedShuttleSystem : EntitySystem
     [Dependency] protected readonly SharedTransformSystem XformSystem = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
 
-    public const float FTLRange = 1024f; // Scav: 256f<1024f
+    public const float FTLRange = 4096f; // Scav: 256f<4096f
     public const float FTLBufferRange = 8f;
     public const float TileDensityMultiplier = 0.5f;
 

--- a/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
+++ b/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Containers.ItemSlots;
+using Content.Shared.Coordinates;
 using Content.Shared.Shuttles.BUIStates;
 using Content.Shared.Shuttles.Components;
 using Content.Shared.Shuttles.UI.MapObjects;
@@ -22,7 +23,7 @@ public abstract partial class SharedShuttleSystem : EntitySystem
     [Dependency] protected readonly SharedTransformSystem XformSystem = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
 
-    public const float FTLRange = 256f;
+    public const float FTLRange = 1024f; // Scav: 256f<1024f
     public const float FTLBufferRange = 8f;
     public const float TileDensityMultiplier = 0.5f;
 
@@ -199,14 +200,15 @@ public abstract partial class SharedShuttleSystem : EntitySystem
         // Just checks if any grids inside of a buffer range at the target position.
         _grids.Clear();
         var mapCoordinates = XformSystem.ToMapCoordinates(coordinates);
+        var shuttleCoordinates = XformSystem.ToMapCoordinates(shuttleUid.ToCoordinates());
 
         var ourPos = Maps.GetGridPosition((shuttleUid, shuttlePhysics, shuttleXform));
 
         // This is the already adjusted position
         var targetPosition = mapCoordinates.Position;
 
-        // Check range even if it's cross-map.
-        if ((targetPosition - ourPos).Length() > FTLRange)
+        // Check range if warping to the same map. // Scav: allow warps to new maps regardless of coordinates. This may need to change if something other than Expeditions use this.
+        if (mapCoordinates.MapId == shuttleCoordinates.MapId && ((targetPosition - ourPos).Length() > FTLRange))
         {
             return false;
         }

--- a/Resources/Prototypes/_NF/Entities/Stations/nanotrasen.yml
+++ b/Resources/Prototypes/_NF/Entities/Stations/nanotrasen.yml
@@ -23,8 +23,7 @@
   id: DebugFrontierStation
   suffix: DEBUG # TODO: Fix this, its here to stop PrototypeSaveTest fail
   parent:
-  - StandardFrontierStation
-  - MarketFrontierOutpost
+  - StandardNanotrasenStation
   categories: [ HideSpawnMenu ]
 
 # region POIs


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Reverted expedition console behavior: they no longer warp the grid they are located on and now eject a disk that can be inserted into a shuttle console
Shuttles are now once more capable of FTL travel
The "Map" tab of the shuttle console now displays a full map of the sector, and visuals have been updated with higher contrast and a directional icon for your own shuttle

## Why / Balance
Expeditions were previously broken and caused the entire station to teleport to the away site. While this was funny, it is decidedly not intended behavior and the original coordinate disk behavior needed to be reinstated.
A common complaint has been that bringing loot to cargo depots is tedious and unfun, reimplimenting FTL should help with that, and also encourage visits to rarely-visited away sites as well as deeper space, which was made more uncommon by the stationary base. The FTL range here may be overtuned and may need to be reduced in a future update, but its good for a first playtest.
The map tab has always felt redundant and ill-suited for the size of Frontier's map, the new layout should give a better big-picture overview and make performing longer-range FTL jumps less awkward. In a future update, a background should be added to make the boundaries of different regions of space clearer, but this is a definite improvement as it is.

## Technical details
Reverted some frontier changes to MapScreen.xaml.cs, SalvageSystem.ExpeditionConsole.cs, SalvageSystem.cs, and SpawnSalvageMissionJob.cs
Changed hardcoded values for the map screen zoom and shuttle FTL range
Changed map to ignore provided offsets when recentering, always jump to the center of the map
Added new behavior to map screen drawing:
- The shuttle being piloted will be displayed with a new, directional icon
- The background has been replaced with a blank grey, which has been made darker (this darkening also applies to other map screen ui elements)
- Items on different maps will no longer be rendered
- The map now forces a refresh when switching to it, rather than staying blank until the user presses a button.
Changed FTL behavior to ignore range limits when warping to a different map (with our map size, the original behavior would make expeditions randomly harder to perform depending on station spawn location)

Also, made slight update to NFDev to use the normal station preset to make it easier to test expedition and cargo features in the future

## How to test
Observe that the expedition console no longer teleports the station and instead prints a coordinate disk
Observe that the FTL button is restored on the shuttle screen, and that the range is much larger than on wizden
Observe that the map screen's visuals have changed

## Media
<img width="998" height="813" alt="image" src="https://github.com/user-attachments/assets/d9e4b78b-8723-40c0-b4df-3c79aab0b271" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Nothing specifically broken, but some change comments from Frontier have been deleted.
Calls to ShuttleMapControl.xaml.cs SetMap() still exist that pass in an offset, but this is ignored. If this update is well-recieved, these should be cleaned up.
In the same file, DrawParallax() is an orphaned function. Either needs to be changed for new image or deleted outright in future update.
The proximity check logic from Frontier was removed from SalvageSystem.ExpeditionConsole. Unsure if Frontier removed this from elsewhere when it moved it here, but I haven't noticed any behavioral issues in testing.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Expedition consoles now produce coordinate disks instead of teleporting the station
- add: Readded FTL functionality to shuttles removed by Frontier
- tweak: FTL range increased significantly from Wizden values
- tweak: Reworked visuals of shuttle console map tab to display the whole sector at once
- tweak: Development map now works with bounty and expedition consoles