### PR TITLE
Expedition Fix and Map Decoration

### DIFF
--- a/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
@@ -13,6 +13,7 @@ using Robust.Shared.Collections;
 using Robust.Shared.Input;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
+using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
@@ -201,6 +202,19 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
         }
     }
 
+    private void DrawCircles(DrawingHandleScreen handle)
+    {
+        var matty = Matrix3Helpers.CreateInverseTransform(Offset, Angle.Zero);
+
+        var center = Vector2.Transform(Vector2.Zero, matty);
+        center = center with { Y = -center.Y };
+        center = ScalePosition(center);
+
+        handle.DrawCircle(center, 5000 * MinimapScale, Color.FromHex("#A78475"), filled: false);
+        handle.DrawCircle(center, 9000 * MinimapScale, Color.FromHex("#A79B75"), filled: false);
+        handle.DrawCircle(center, 15000 * MinimapScale, Color.FromHex("#7593A7"), filled: false);
+    }
+
     /// <summary>
     /// Gets the map objects that intersect the viewport.
     /// </summary>
@@ -251,6 +265,7 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
         }
 
         DrawBacking(handle); // Scav: no longer drawing parallax, just blank background
+        DrawCircles(handle);
 
         var viewedMapUid = _mapSystem.GetMapOrInvalid(ViewingMap);
         var matty = Matrix3Helpers.CreateInverseTransform(Offset, Angle.Zero);

--- a/Content.Server/Salvage/SalvageSystem.Expeditions.cs
+++ b/Content.Server/Salvage/SalvageSystem.Expeditions.cs
@@ -268,9 +268,6 @@ public sealed partial class SalvageSystem
             _dungeon,
             _metaData,
             _mapSystem,
-            _station, // Frontier
-            _shuttle, // Frontier
-            this, // Frontier
             station,
             coordinatesDisk,
             missionParams,

--- a/Content.Server/Salvage/SpawnSalvageMissionJob.cs
+++ b/Content.Server/Salvage/SpawnSalvageMissionJob.cs
@@ -35,8 +35,6 @@ using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using Content.Server.Shuttles.Components;
 using Content.Server._NF.Salvage.Expeditions; // Frontier
-using Content.Server.Station.Components; // Frontier
-using Content.Server.Station.Systems; // Frontier
 using Content.Server.Shuttles.Systems;
 using Content.Server._NF.Salvage.Expeditions.Structure; // Frontier
 
@@ -52,9 +50,6 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
     private readonly DungeonSystem _dungeon;
     private readonly MetaDataSystem _metaData;
     private readonly SharedMapSystem _map;
-    private readonly StationSystem _station; // Frontier
-    private readonly ShuttleSystem _shuttle; // Frontier
-    private readonly SalvageSystem _salvage; // Frontier
 
     public readonly EntityUid Station;
     public readonly EntityUid? CoordinatesDisk;
@@ -80,9 +75,6 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
         DungeonSystem dungeon,
         MetaDataSystem metaData,
         SharedMapSystem map,
-        StationSystem stationSystem, // Frontier
-        ShuttleSystem shuttleSystem, // Frontier
-        SalvageSystem salvageSystem, // Frontier
         EntityUid station,
         EntityUid? coordinatesDisk,
         SalvageMissionParams missionParams,
@@ -96,9 +88,6 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
         _dungeon = dungeon;
         _metaData = metaData;
         _map = map;
-        _station = stationSystem; // Frontier
-        _shuttle = shuttleSystem; // Frontier
-        _salvage = salvageSystem; // Frontier
         Station = station;
         CoordinatesDisk = coordinatesDisk;
         _missionParams = missionParams;
@@ -150,7 +139,7 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
         _metaData.SetEntityName(
             mapUid,
             _entManager.System<SharedSalvageSystem>().GetFTLName(_prototypeManager.Index(SalvageSystem.PlanetNames), _missionParams.Seed));
-        _entManager.AddComponent<FTLBeaconComponent>(mapUid);
+        var beacon = _entManager.AddComponent<FTLBeaconComponent>(mapUid);
 
         // Saving the mission mapUid to a CD is made optional, in case one is somehow made in a process without a CD entity
         if (CoordinatesDisk.HasValue)
@@ -246,26 +235,15 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
             dungeonBox = dungeonBox.ExtendToContain(tile);
         }
 
-        var stationData = _entManager.GetComponent<StationDataComponent>(Station);
-
-        // Get ship bounding box relative to largest grid coords
-        var shuttleUid = _station.GetLargestGrid(stationData);
-        Box2 shuttleBox = new Box2();
-
-        if (shuttleUid is { Valid: true } vesselUid &&
-            _entManager.TryGetComponent<MapGridComponent>(vesselUid, out var gridComp))
-        {
-            shuttleBox = gridComp.LocalAABB;
-        }
-
         // Offset ship spawn point from bounding boxes
         float sin = (float)Math.Sin(dungeonRotation);
         float cos = (float)Math.Cos(dungeonRotation);
         Vector2 dungeonProjection = new Vector2(dungeonBox.Width * -sin / 2, dungeonBox.Height * cos / 2); // Project boxes to get relevant offset for dungeon rotation.
-        Vector2 shuttleProjection = new Vector2(shuttleBox.Width * -sin / 2, shuttleBox.Height * cos / 2); // Note: sine is negative because of CCW rotation (starting north, then west)
-        Vector2 coords = dungeonBox.Center - dungeonProjection - dungeonOffset - shuttleProjection - shuttleBox.Center; // Coordinates to spawn the ship at to center it with the dungeon's bounding boxes
+        Vector2 coords = dungeonBox.Center - dungeonProjection - dungeonOffset; // Coordinates to spawn the ship at to center it with the dungeon's bounding boxes //Scav: Removed shuttle part of the offset, will apply that on FTL instead.
         coords = coords.Rounded(); // Ensure grid is aligned to map coords
 
+        beacon.Coords = coords;
+        beacon.Rotation = dungeonRotation;
         // List<Vector2i> reservedTiles = new();
 
         // foreach (var tile in _map.GetTilesIntersecting(mapUid, grid, new Circle(Vector2.Zero, landingPadRadius), false))

--- a/Content.Server/Shuttles/Components/FTLBeaconComponent.cs
+++ b/Content.Server/Shuttles/Components/FTLBeaconComponent.cs
@@ -1,3 +1,5 @@
+using System.Numerics;
+
 namespace Content.Server.Shuttles.Components;
 
 /// <summary>
@@ -6,5 +8,15 @@ namespace Content.Server.Shuttles.Components;
 [RegisterComponent]
 public sealed partial class FTLBeaconComponent : Component
 {
+    /// <summary>
+    /// Coords to use when FTLing to a destination. Used to ensure that landing is outside of a dungeon, for example.
+    /// </summary>
+    [DataField]
+    public Vector2 Coords = Vector2.Zero;
 
+    /// <summary>
+    /// Angle rotation used to apply the shuttle offset relative to.
+    /// </summary>
+    [DataField]
+    public Angle Rotation = Angle.Zero;
 }

--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.FTL.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.FTL.cs
@@ -1,5 +1,7 @@
+using System.Numerics;
 using Content.Server.Shuttles.Components;
 using Content.Server.Shuttles.Events;
+using Content.Server.Station.Components;
 using Content.Shared.Shuttles.BUIStates;
 using Content.Shared.Shuttles.Components;
 using Content.Shared.Shuttles.Events;
@@ -42,6 +44,11 @@ public sealed partial class ShuttleConsoleSystem
         {
             return;
         }
+        // Scav: explicit query for beacon, we need data off it
+        if (!_beaconQuery.TryGetComponent(beaconEnt, out var beaconComp))
+        {
+            return;
+        }
 
         var nCoordinates = new NetCoordinates(GetNetEntity(targetXform.ParentUid), targetXform.LocalPosition);
         if (targetXform.ParentUid == EntityUid.Invalid)
@@ -55,10 +62,35 @@ public sealed partial class ShuttleConsoleSystem
             return;
         }
 
-        var angle = args.Angle.Reduced();
-        var targetCoordinates = new EntityCoordinates(targetXform.MapUid!.Value, _transform.GetWorldPosition(targetXform));
+        var station = _station.GetOwningStation(ent.Owner);
+        if (beaconComp.Coords != Vector2.Zero && TryComp<StationDataComponent>(station, out var stationData))
+        {
+            // Get ship bounding box relative to largest grid coords
+            var shuttleUid = _station.GetLargestGrid(stationData);
+            Box2 shuttleBox = new Box2();
 
-        ConsoleFTL(ent, targetCoordinates, angle, targetXform.MapID);
+            if (shuttleUid is { Valid: true } vesselUid &&
+                TryComp<MapGridComponent>(vesselUid, out var gridComp))
+            {
+                shuttleBox = gridComp.LocalAABB;
+            }
+
+            float sin = (float)Math.Sin(beaconComp.Rotation);
+            float cos = (float)Math.Cos(beaconComp.Rotation);
+            Vector2 shuttleProjection = new Vector2(shuttleBox.Width * -sin / 2, shuttleBox.Height * cos / 2); // Note: sine is negative because of CCW rotation (starting north, then west)
+
+            var coords = beaconComp.Coords - shuttleProjection - shuttleBox.Center;
+            var targetCoordinates = new EntityCoordinates(targetXform.MapUid!.Value, coords);
+
+            ConsoleFTL(ent, targetCoordinates, 0, targetXform.MapID);
+        }
+        else
+        {
+            var angle = args.Angle.Reduced();
+            var targetCoordinates = new EntityCoordinates(targetXform.MapUid!.Value, _transform.GetWorldPosition(targetXform));
+            ConsoleFTL(ent, targetCoordinates, angle, targetXform.MapID);
+        }
+
     }
 
     private void OnPositionFTLMessage(Entity<ShuttleConsoleComponent> entity, ref ShuttleConsoleFTLPositionMessage args)

--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
@@ -45,6 +45,7 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
 
     private EntityQuery<MetaDataComponent> _metaQuery;
     private EntityQuery<TransformComponent> _xformQuery;
+    private EntityQuery<FTLBeaconComponent> _beaconQuery; //Scav
 
     private readonly HashSet<Entity<ShuttleConsoleComponent>> _consoles = new();
 
@@ -56,6 +57,7 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
 
         _metaQuery = GetEntityQuery<MetaDataComponent>();
         _xformQuery = GetEntityQuery<TransformComponent>();
+        _beaconQuery = GetEntityQuery<FTLBeaconComponent>(); //Scav
 
         SubscribeLocalEvent<ShuttleConsoleComponent, ComponentShutdown>(OnConsoleShutdown);
         SubscribeLocalEvent<ShuttleConsoleComponent, PowerChangedEvent>(OnConsolePowerChange);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed expeditions not landing correctly, added rings on the map screen denoting the rings on the map

## Why / Balance
Shuttles spawning in the middle of the dungeon isnt intended behavior, and some decoration on the map will help with getting your bearings

## Technical details
Added Offset and Angle to FTLBeaconComponent. A modified version of Frontier's landing coordinates logic is written to this, and read by the shuttle console when FTLing to the beacon (the logic was split into both sides of this, since half relies on the worldgen and half on the shuttle's grid)
Removed station, shuttle, and salvage systems passed into SpawnSalvageMissionJob as they are not needed anymore
xaml changes to map screen

## How to test
Start an expedition, note that you now land outside the dungeon instead of in the middle of it

## Media
<img width="969" height="781" alt="image" src="https://github.com/user-attachments/assets/72130fed-5eda-45e3-b572-e5af431653cf" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Removed unused parameters from SpawnSalvageMissionJob
OnBeaconFTLMessage now explicitly requires a beacon component on the destination


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Expeditions now land you outside the dungeon correctly again
- add: Added rings on the sector map to denote the regions of the world
