### PR TITLE
Quick fix to rounds failing to restart after bank persistence update

### DIFF
--- a/Content.Server/_Scav/GameRule/ScavAdventureRuleSystem.cs
+++ b/Content.Server/_Scav/GameRule/ScavAdventureRuleSystem.cs
@@ -285,6 +285,7 @@ public sealed class ScavAdventureRuleSystem : GameRuleSystem<ScavAdventureRuleCo
     private void OnRoundRestart(RoundRestartCleanupEvent ev)
     {
         _players.Clear();
+        _stations.Clear();
     }
 
     protected override void Started(EntityUid uid, ScavAdventureRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed bug from station bank persistence PR that caused rounds to not restart properly

## Why / Balance
Bugfix

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed rounds failing to start after a round with a persistent station bank ended
