### PR TITLE
Recycler Changes

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
@@ -2,7 +2,7 @@
   id: Recycler
   parent: BaseMachinePowered
   name: industrial recycler
-  description: A large crushing machine used to recycle small items inefficiently. There are lights on the side.
+  description: A large crushing machine used to recycle things into their component materials. There are lights on the side.
   components:
   - type: AmbientSound
     enabled: false

--- a/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: Recycler
   parent: BaseMachinePowered
-  name: recycler
+  name: industrial recycler
   description: A large crushing machine used to recycle small items inefficiently. There are lights on the side.
   components:
   - type: AmbientSound
@@ -26,9 +26,10 @@
           bounds: "-0.49,-0.49,0.49,0.49"
         hard: true
         mask:
-        - Impassable
+        - MachineMask
         layer:
         - Opaque
+        - MidImpassable
         - BulletImpassable
       conveyor:
         shape: !type:PolygonShape

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/flatpacks.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/flatpacks.yml
@@ -338,8 +338,8 @@
 - type: entity
   parent: UniformPrinterFlatpack
   id: MaterialReclaimerFlatpack
-  name: material reclaimer flatpack
-  description: A flatpack used for constructing a material reclaimer.
+  name: recycler flatpack
+  description: A flatpack used for constructing a portable recycler.
   components:
   - type: Flatpack
     entity: MaterialReclaimer

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/production.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/production.yml
@@ -620,8 +620,8 @@
 - type: entity
   id: MaterialReclaimerMachineCircuitboard
   parent: BaseMachineCircuitboard
-  name: material reclaimer machine board
-  description: A machine printed circuit board for a material reclaimer.
+  name: recycler machine board
+  description: A machine printed circuit board for a recycler.
   components:
     - type: Sprite
       state: supply

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/material_reclaimer.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/material_reclaimer.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: [ BaseMachinePowered, ConstructibleMachine ]
   id: MaterialReclaimer
-  name: material reclaimer
+  name: recycler
   description: Cannot reclaim immaterial things, like motivation.
   components:
   - type: Sprite
@@ -62,6 +62,7 @@
     board: MaterialReclaimerMachineCircuitboard
   - type: WiresPanel
   - type: MaterialReclaimer
+    efficiency: 0.75 # Scav
     whitelist:
       components:
       - PhysicalComposition


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed hitbox on recycler, nerfed material reclaimer, renamed so recycler is now industrial recycler and reclaimer is recyler

## Why / Balance
The recycler being intangible is an oddity and frankly feels extremely glitchy. This fixes that
Nerfed the material reclaimer to make the industrial variant preferable, while the small ones are convenient for quick item disposal
Renamed and changed flavor text to make it clearer they're the same thing

## Technical details
Yaml, mostly flavortext but collision mask was the most important functional change.

## How to test
Walk into an industrial recycler, observe you dont phase through it anymore (unless crawling)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Might possibly break recycling things like intact broken machines? But that's manageable.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Recycler now has correct collision instead of being intangible to players
- tweak: Renamed recycler to "Industrial Recycler", and material reclaimer to "Recycler", changed flavor text
- tweak: Nerfed the machine formerly called the reclaimer. It now only returns materials at 75% the efficiency of the industrial variant
