### PR TITLE
Zero Gravity Control Adjustment

### DIFF
--- a/Content.Shared/Movement/Systems/MovementIgnoreGravitySystem.cs
+++ b/Content.Shared/Movement/Systems/MovementIgnoreGravitySystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Gravity;
+﻿using Content.Shared._Scav.Movement;
+using Content.Shared.Gravity;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Events;
 
@@ -7,12 +8,26 @@ namespace Content.Shared.Movement.Systems;
 public sealed class MovementIgnoreGravitySystem : EntitySystem
 {
     [Dependency] SharedGravitySystem _gravity = default!;
+
+    private EntityQuery<TransformComponent> _xformQuery;
+
     public override void Initialize()
     {
         SubscribeLocalEvent<MovementAlwaysTouchingComponent, CanWeightlessMoveEvent>(OnWeightless);
+        SubscribeLocalEvent<MovementFloorCountsAsTouchingComponent, CanWeightlessMoveEvent>(OnFloorWeightless);
         SubscribeLocalEvent<MovementIgnoreGravityComponent, IsWeightlessEvent>(OnIsWeightless);
         SubscribeLocalEvent<MovementIgnoreGravityComponent, ComponentStartup>(OnComponentStartup);
+
+        _xformQuery = GetEntityQuery<TransformComponent>();
     }
+
+    // Scav: Added handler for MovementFloorCountsAsTouchingComponent
+    private void OnFloorWeightless(Entity<MovementFloorCountsAsTouchingComponent> entity, ref CanWeightlessMoveEvent args)
+    {
+        if (_xformQuery.TryGetComponent(entity.Owner, out var xform) && xform.GridUid != null)
+            args.CanMove = true;
+    }
+    // End Scav
 
     private void OnWeightless(Entity<MovementAlwaysTouchingComponent> entity, ref CanWeightlessMoveEvent args)
     {

--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -236,7 +236,7 @@ public abstract partial class SharedMoverController : VirtualController
             var ev = new CanWeightlessMoveEvent(uid);
             RaiseLocalEvent(uid, ref ev, true);
 
-            touching = ev.CanMove || xform.GridUid != null || MapGridQuery.HasComp(xform.GridUid);
+            touching = ev.CanMove; // || xform.GridUid != null || MapGridQuery.HasComp(xform.GridUid); //Scav: floor no longer counts as touching
 
             // If we're not on a grid, and not able to move in space check if we're close enough to a grid to touch.
             if (!touching && MobMoverQuery.TryComp(uid, out var mobMover))

--- a/Content.Shared/_Scav/Movement/MovementFloorCountsAsTouchingComponent.cs
+++ b/Content.Shared/_Scav/Movement/MovementFloorCountsAsTouchingComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Scav.Movement;
+
+/// <summary>
+/// Does being above the floor count as touching a wall?
+/// Restores the old style of zero-g movement for this entity, without being as extensive as MovementAlwaysTouchingComponent
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class MovementFloorCountsAsTouchingComponent : Component
+{
+
+}

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -50,9 +50,9 @@
       Female: UnisexMoth
       Unsexed: UnisexMoth
   - type: MovementSpeedModifier
-    baseWeightlessAcceleration: 1.5 # Move around more easily in space.
-    baseWeightlessFriction: 1
-    baseWeightlessModifier: 1
+    baseWeightlessAcceleration: 1.1 # Move around more easily in space. # Scav: 1.5<1.1
+    #baseWeightlessFriction: 1 # Scav
+    #baseWeightlessModifier: 1 # Scav
   - type: Flammable
     damage:
       types:

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -74,6 +74,7 @@
       275: 0.8
       250: 0.7
   - type: FluffyWhitelist # Frontier
+  - type: MovementFloorCountsAsTouching # Scav
   - type: Sprite # sprite again because we want different layer ordering
     noRot: true
     drawdepth: Mobs


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Free movement in space now no longer treats having a floor below you as if you have a wall to push off of. Magboots and jetpacks are unaffected, and players can still maneuver if they are adjacent to a wall (essentially, zero-g movement indoors and on asteroids behaves how EVA in open space worked previously).
Moths are exempt from this change, but have had their zero-g speed buff reduced to compensate.

## Why / Balance
The existing system resulted in most zero-g situations to feel less like floating weightlessly and more like swimming through molasses. This introduces more realism as well as shockingly better game feel
This will have little impact on actual game balance, as it can be completely negated by using magboots or jetpacks (which salvagers should be using anyway)

## Technical details
Commented out a single line of code in HandleMobMovement
Added new MovementFloorCountsAsTouchingComponent. Works like MovementAlwaysTouchingComponent but simply restores the old functionality instead of working everywhere
Applied the prior component to Moth People and reduced their movement speed modifier significantly in yaml

## How to test
Enter an area with zero gravity
Observe that you need to push off walls to move and cant move freely

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
Shouldn't be any breaking changes, but keep an eye out for any mobs that don't behave properly (Most if not all Frontier mobs have MovementIgnoreGravityComponent and/or MovementAlwaysTouchingComponent anyway so they're largely unaffected in my testing)

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Zero-gravity movement no longer lets you maneuver with floor beneath you, only walls.
- tweak: Nerfed moth spacemove speed as they are exempt from the prior change
